### PR TITLE
0.1.4

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.4
+
+- 🩹 Use brackets to indicate cached jobs
+- 🩹 Run on_complete hook only when no exception happened
+- 🩹 Let `on_proc_init` to modify process `workdir`
+- 🐛 Fix when `nexts` affected by parent `nexts` assignment when parent in `__bases__`
+
 ## 0.1.3
 
 - ✨ Add `on_proc_init()` hook to enables plugins to modify the default attributes of processes

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -178,9 +178,12 @@ The above code will produce some logging on the console like this:
 
 - [`pipen-verbose`][3]: Add verbosal information in logs for pipen.
 - [`pipen-report`][4]: Generate report for pipen
+- [`pipen-filters`][8]: Add a set of useful filters for pipen templates.
 - [`pipen-diagram`][5]: Draw pipeline diagrams for pipen
 - [`pipen-args`][6]: Command line argument parser for pipen
-- More to add ...
+- [`pipen-dry`][7]: Dry runner for pipen pipelines
+- [`pipen-cli-init`][9]: A pipen CLI plugin to create a pipen project (pipeline)
+
 
 
 [1]: https://github.com/pwwang/simplug
@@ -189,3 +192,6 @@ The above code will produce some logging on the console like this:
 [4]: https://github.com/pwwang/pipen-report
 [5]: https://github.com/pwwang/pipen-diagram
 [6]: https://github.com/pwwang/pipen-args
+[7]: https://github.com/pwwang/pipen-dry
+[8]: https://github.com/pwwang/pipen-filters
+[9]: https://github.com/pwwang/pipen-cli-init

--- a/pipen/pipen.py
+++ b/pipen/pipen.py
@@ -141,8 +141,11 @@ class Pipen:
                 proc_obj.gc()
 
             logger.info("")
-        finally:
+        except Exception:
+            raise
+        else:
             await plugin.hooks.on_complete(self, succeeded)
+        finally:
             self.plugin_context.__exit__()
             if self.pbar:
                 self.pbar.done()

--- a/pipen/proc.py
+++ b/pipen/proc.py
@@ -416,7 +416,7 @@ class Proc(ABC, metaclass=ProcMeta):
                 job.status = JobStatus.FINISHED
             await self.xqute.put(job)
         if cached_jobs:
-            self.log("info", "Cached jobs: %s", brief_list(cached_jobs))
+            self.log("info", "Cached jobs: [%s]", brief_list(cached_jobs))
         await self.xqute.run_until_complete()
         self.pbar.done()
         await plugin.hooks.on_proc_done(

--- a/pipen/proc.py
+++ b/pipen/proc.py
@@ -278,15 +278,15 @@ class Proc(ABC, metaclass=ProcMeta):
         # instance properties
         self.pipeline = pipeline
 
-        # plugins can modify some default attributes
-        plugin.hooks.on_proc_init(self)
-
         self.pbar = None
         self.jobs: List[Any] = []
         self.xqute = None
         self.__class__.workdir = Path(self.pipeline.workdir) / slugify(
             self.name
         )
+
+        # plugins can modify some default attributes
+        plugin.hooks.on_proc_init(self)
 
         # Compute the properties
         # otherwise, the property can be accessed directly from class vars

--- a/pipen/proc.py
+++ b/pipen/proc.py
@@ -462,11 +462,15 @@ class Proc(ABC, metaclass=ProcMeta):
         if is_subclass(requires, Proc):
             requires = [requires]  # type: ignore
 
+        # if req is in cls.__bases__, then cls.nexts will be affected by
+        # req.nexts
+        my_nexts = None if cls.nexts is None else cls.nexts[:]
         for req in requires:  # type: ignore
             if req.nexts is None:
                 req.nexts = [cls]
             else:
                 req.nexts.append(cls)  # type: ignore
+        cls.nexts = my_nexts
 
         return requires  # type: ignore
 

--- a/pipen/version.py
+++ b/pipen/version.py
@@ -1,3 +1,3 @@
 """Provide version of pipen"""
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "pipen"
-version = "0.1.3"
+version = "0.1.4"
 description = "A pipeline framework for python"
 authors = [ "pwwang <pwwang@pwwang.com>",]
 license = "MIT"


### PR DESCRIPTION
- 🩹 Use brackets to indicate cached jobs
- 🩹 Run on_complete hook only when no exception happened
- 🩹 Let `on_proc_init` to modify process `workdir`
- 🐛 Fix when `nexts` affected by parent `nexts` assignment when parent in `__bases__`