### PR TITLE
🔖 0.2.13

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.13
+
+- 🩹 Don't require `job.signature.toml` to force cache a job
+
 ## 0.2.12
 
 - 🐛 Hotfix for typos in `Proc.__init_subclass__()`

--- a/pipen/_job_caching.py
+++ b/pipen/_job_caching.py
@@ -204,15 +204,15 @@ class JobCaching:
                 "Not cached (job.rc != 0)",
             )
             out = False
+        elif proc_cache == "force":
+            await self.cache()
+            out = True
         elif not self.signature_file.is_file():
             self.log(
                 "debug",
                 "Not cached (signature file not found)",
             )
             out = False
-        elif proc_cache == "force":
-            await self.cache()
-            out = True
         else:
             out = await self._check_cached()
 

--- a/pipen/version.py
+++ b/pipen/version.py
@@ -1,3 +1,3 @@
 """Provide version of pipen"""
 
-__version__ = "0.2.12"
+__version__ = "0.2.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "pipen"
-version = "0.2.12"
+version = "0.2.13"
 description = "A pipeline framework for python"
 authors = [ "pwwang <pwwang@pwwang.com>",]
 license = "MIT"


### PR DESCRIPTION
- 🩹 Don't require `job.signature.toml` to force cache a job