### PR TITLE
🔖 0.2.14

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 - 🩹 Shorten pipeline info in log for long config options
 - 🐛 Fix cached jobs being put into queue
 - 🩹 Shorten job debug messages when hit limits
+- 🚑 Remove sort_dicts for pprint.pformat for py3.7
 
 ## 0.2.13
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.14
+
+- 🩹 Shorten pipeline info in log for long config options
+- 🐛 Fix cached jobs being put into queue
+- 🩹 Shorten job debug messages when hit limits
+
 ## 0.2.13
 
 - 🩹 Don't require `job.signature.toml` to force cache a job

--- a/pipen/job.py
+++ b/pipen/job.py
@@ -232,10 +232,7 @@ class Job(XquteJob, JobCaching):
 
         if self.index == limit:
             if limit_indicator:
-                self.proc.log(
-                    "debug", "Not showing similar logs for further jobs."
-                )
-            return
+                msg = f"{msg} (not showing similar logs)"
 
         job_index_indicator = "[%s/%s] " % (
             str(self.index).zfill(len(str(self.proc.size - 1))),

--- a/pipen/pipen.py
+++ b/pipen/pipen.py
@@ -316,7 +316,7 @@ class Pipen:
                             for key, val in self.config.template_opts.items()
                         },
                         indent=1,
-                        sort_dicts=False,
+                        # sort_dicts=False,
                     ),
                 ),
             ),

--- a/pipen/pipen.py
+++ b/pipen/pipen.py
@@ -3,6 +3,8 @@ import asyncio
 from itertools import chain
 from os import PathLike
 from pathlib import Path
+import pprint
+import textwrap
 from typing import ClassVar, Iterable, List, Sequence, Type, Union
 
 from diot import Diot
@@ -209,7 +211,7 @@ class Pipen:
     def set_starts(
         self,
         *procs: Union[Type[Proc], Sequence[Type[Proc]]],
-        clear: bool = True
+        clear: bool = True,
     ):
         """Set the starts
 
@@ -276,12 +278,53 @@ class Pipen:
                     self.outdir,
                 ],
             ),
-            sorted(self.config.items()),
+            sorted(
+                (key, val)
+                for key, val in self.config.items()
+                if not key.endswith("_opts")
+            ),
+            (
+                (
+                    "plugin_opts",
+                    pprint.pformat(self.config.plugin_opts, indent=1),
+                ),
+                (
+                    "scheduler_opts",
+                    pprint.pformat(self.config.scheduler_opts, indent=1),
+                ),
+                (
+                    "template_opts",
+                    pprint.pformat(
+                        {
+                            key: (
+                                {
+                                    ckey: textwrap.shorten(
+                                        str(cval),
+                                        width=30 - len(key),
+                                        placeholder=" …",
+                                    )
+                                    for ckey, cval in chain(
+                                        list(val.items())[:3],
+                                        []
+                                        if len(val) <= 3
+                                        else [("...", "...")],
+                                    )
+                                }
+                                if isinstance(val, dict)
+                                else val
+                            )
+                            for key, val in self.config.template_opts.items()
+                        },
+                        indent=1,
+                        sort_dicts=False,
+                    ),
+                ),
+            ),
         ):
             items_table.add_row(
                 Text.assemble((key, "scope.key")),
                 Text.assemble(("=", "scope.equals")),
-                str(value),
+                Text(str(value), overflow="fold"),
             )
 
         logger.info("")
@@ -357,8 +400,7 @@ class Pipen:
             logger.debug("- Next processes: %s", nexts)
             # pick up one that can be added to procs
             for proc in sorted(
-                nexts,
-                key=lambda prc: (prc.order or 0, prc.name)
+                nexts, key=lambda prc: (prc.order or 0, prc.name)
             ):
                 if proc in self.procs:
                     raise ProcDependencyError(

--- a/pipen/proc.py
+++ b/pipen/proc.py
@@ -449,7 +449,8 @@ class Proc(ABC, metaclass=ProcMeta):
                 self.pbar.update_job_running()
                 self.pbar.update_job_succeeded()
                 job.status = JobStatus.FINISHED
-            await self.xqute.put(job)
+            else:
+                await self.xqute.put(job)
         if cached_jobs:
             self.log("info", "Cached jobs: [%s]", brief_list(cached_jobs))
         await self.xqute.run_until_complete()

--- a/pipen/version.py
+++ b/pipen/version.py
@@ -1,3 +1,3 @@
 """Provide version of pipen"""
 
-__version__ = "0.2.13"
+__version__ = "0.2.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "pipen"
-version = "0.2.13"
+version = "0.2.14"
 description = "A pipeline framework for python"
 authors = [ "pwwang <pwwang@pwwang.com>",]
 license = "MIT"

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -263,7 +263,7 @@ def test_job_log_limit(caplog, pipen):
 
     caplog.clear()
     pipen.set_starts(proc2).run()
-    assert "Not showing similar logs" in caplog.text
+    assert "showing similar logs" in caplog.text
 
 
 def test_wrong_input_type(pipen):


### PR DESCRIPTION
- 🩹 Shorten pipeline info in log for long config options
- 🐛 Fix cached jobs being put into queue
- 🩹 Shorten job debug messages when hit limits
- 🚑 Remove sort_dicts for pprint.pformat for py3.7