### PR TITLE
0.3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,5 @@ t-*.ipynb
 *-output/
 *_results/
 t.py
+
+nohup.out

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.4
+
+- ✨ Print pipen version in CLI: pipen plugins
+- 🩹 Make use of full terminal width for non-panel elements in log
+- 🩹 Extend width to 256 when terminal width cannot be detected while logging (most likely logging to a text file)
+
 ## 0.3.3
 
 - ♿️ Change default log width to 100

--- a/pipen/cli/plugins.py
+++ b/pipen/cli/plugins.py
@@ -117,6 +117,8 @@ class CliPluginsPlugin(CLIPlugin):
 
     def exec_command(self, args: Mapping[str, Any]) -> None:
         """Execute the command"""
+        from ..version import __version__
+        print("Pipen version:", __version__)
 
         plugins: List[Tuple[str, str, Any]] = []
 

--- a/pipen/defaults.py
+++ b/pipen/defaults.py
@@ -57,11 +57,18 @@ CONFIG = Diot(
     plugin_opts={},
 )
 
-CONSOLE_WIDTH: int = 100
+# Just the total width of the terminal
+# when logging with a rich.Panel()
+CONSOLE_WIDTH_WITH_PANEL: int = 100
+# The width of the terminal when the width cannot be detected,
+# we are probably logging into a file
+CONSOLE_DEFAULT_WIDTH: int = 256
 # [05/16/22 11:46:40] I
+# v0.3.4:
+# 05-16 11:11:11 I
 # The markup code is included
 # Don't modify this unless the logger formatter is changed
-CONSOLE_WIDTH_SHIFT: int = 30
+CONSOLE_WIDTH_SHIFT: int = 25
 # For pipen scheduler plugins
 SCHEDULER_ENTRY_GROUP = "pipen_sched"
 # For pipen template plugins

--- a/pipen/pipen.py
+++ b/pipen/pipen.py
@@ -17,14 +17,14 @@ from simpleconf import ProfileConfig
 from slugify import slugify  # type: ignore
 from varname import varname, VarnameException
 
-from .defaults import CONFIG, CONFIG_FILES, CONSOLE_WIDTH, CONSOLE_WIDTH_SHIFT
+from .defaults import CONFIG, CONFIG_FILES
 from .exceptions import ProcDependencyError, PipenSetDataError
 from .pluginmgr import plugin
 from .proc import Proc
 from .progressbar import PipelinePBar
 from .utils import (
     copy_dict,
-    get_logcontent_width,
+    get_logpanel_width,
     get_plugin_context,
     log_rich_renderable,
     logger,
@@ -338,9 +338,7 @@ class Pipen:
             Panel(
                 Group(*items),
                 title=self.name.upper(),
-                width=get_logcontent_width(
-                    max_width=CONSOLE_WIDTH - CONSOLE_WIDTH_SHIFT
-                ),
+                width=get_logpanel_width(),
                 box=box.Box(
                     "╭═┬╮\n"
                     "║ ║║\n"

--- a/pipen/proc.py
+++ b/pipen/proc.py
@@ -25,7 +25,7 @@ from slugify import slugify  # type: ignore
 from varname import VarnameException, varname
 from xqute import JobStatus, Xqute
 
-from .defaults import CONSOLE_WIDTH, CONSOLE_WIDTH_SHIFT, ProcInputType
+from .defaults import ProcInputType
 from .exceptions import (
     ProcInputKeyError,
     ProcInputTypeError,
@@ -40,7 +40,7 @@ from .utils import (
     cached_property,
     copy_dict,
     desc_from_docstring,
-    get_logcontent_width,
+    get_logpanel_width,
     ignore_firstline_dedent,
     is_subclass,
     log_rich_renderable,
@@ -681,9 +681,7 @@ class Proc(ABC, metaclass=ProcMeta):
             )
             if self.export
             else box.ROUNDED,
-            width=get_logcontent_width(
-                max_width=CONSOLE_WIDTH - CONSOLE_WIDTH_SHIFT
-            ),
+            width=get_logpanel_width(),
         )
 
         logger.info("")

--- a/pipen/utils.py
+++ b/pipen/utils.py
@@ -2,7 +2,7 @@
 import logging
 import textwrap
 from io import StringIO
-from os import PathLike
+from os import PathLike, get_terminal_size
 from collections import defaultdict
 from pathlib import Path
 from typing import (
@@ -34,16 +34,24 @@ except ImportError:  # pragma: no cover
     import importlib_metadata
 
 from more_itertools import consecutive_groups
-from rich.console import Console, RenderableType
+from rich.console import Console
 from rich.logging import RichHandler as _RichHandler
 from rich.table import Table
 from rich.text import Text
 from simplug import SimplugContext
 
-from .defaults import CONSOLE_WIDTH, CONSOLE_WIDTH_SHIFT, LOGGER_NAME
+from .defaults import (
+    CONSOLE_DEFAULT_WIDTH,
+    CONSOLE_WIDTH_WITH_PANEL,
+    CONSOLE_WIDTH_SHIFT,
+    LOGGER_NAME,
+)
 from .exceptions import ConfigurationError
 from .pluginmgr import plugin
 from .version import __version__
+
+if TYPE_CHECKING:  # pragma: no cover
+    from rich.console import RenderableType, ConsoleRenderable
 
 
 class RichHandler(_RichHandler):
@@ -54,7 +62,7 @@ class RichHandler(_RichHandler):
         """Get the level name from the record.
 
         Args:
-            record (LogRecord): LogRecord instance.
+            record: LogRecord instance.
 
         Returns:
             Text: A tuple of the style and level name.
@@ -67,6 +75,11 @@ class RichHandler(_RichHandler):
 
 
 logger_console = Console()
+try:
+    get_terminal_size()
+except (AttributeError, ValueError, OSError):  # maybe not a terminal
+    if logger_console._environ.get("COLUMNS") is None:
+        logger_console.width = CONSOLE_DEFAULT_WIDTH
 
 _logger_handler = RichHandler(
     show_path=False,
@@ -75,6 +88,7 @@ _logger_handler = RichHandler(
     rich_tracebacks=True,
     omit_repeated_times=False,  # rich 10+
     markup=True,
+    log_time_format="%m-%d %H:%M:%S",
 )
 _logger_handler.setFormatter(
     logging.Formatter("[purple]%(plugin_name)-7s[/purple] %(message)s")
@@ -236,7 +250,7 @@ def copy_dict(dic: Mapping[str, Any], depth: int = 1) -> Mapping[str, Any]:
     }
 
 
-def get_logcontent_width(max_width: int = None) -> int:
+def get_logpanel_width() -> int:
     """Get the width of the log content
 
     Args:
@@ -248,15 +262,13 @@ def get_logcontent_width(max_width: int = None) -> int:
     Returns:
         The width of the log content
     """
-    try:
-        out = logger_console.width - CONSOLE_WIDTH_SHIFT
-    except (AttributeError, IndexError):  # pragma: no cover
-        out = CONSOLE_WIDTH - CONSOLE_WIDTH_SHIFT
-
-    if max_width is not None and out > max_width:  # pragma: no cover
-        out = max_width
-
-    return out
+    return (
+        min(
+            logger_console.width,
+            CONSOLE_WIDTH_WITH_PANEL,
+        )
+        - CONSOLE_WIDTH_SHIFT
+    )
 
 
 def get_plugin_context(plugins: List[Any]) -> SimplugContext:
@@ -286,7 +298,7 @@ def get_plugin_context(plugins: List[Any]) -> SimplugContext:
 
 
 def log_rich_renderable(
-    renderable: RenderableType,
+    renderable: "RenderableType",
     color: str,
     logfunc: Callable,
     *args: Any,
@@ -335,16 +347,14 @@ def brief_list(blist: List[int]) -> str:
     return ", ".join(ret)
 
 
-def pipen_banner() -> RenderableType:
+def pipen_banner() -> "RenderableType":
     """The banner for pipen
 
     Returns:
         The banner renderable
     """
     table = Table(
-        width=get_logcontent_width(
-            max_width=CONSOLE_WIDTH - CONSOLE_WIDTH_SHIFT
-        ),
+        width=get_logpanel_width(),
         show_header=False,
         show_edge=False,
         show_footer=False,

--- a/pipen/utils.py
+++ b/pipen/utils.py
@@ -66,7 +66,7 @@ class RichHandler(_RichHandler):
         return level_text
 
 
-logger_console = Console(_environ={"COLUMNS": str(CONSOLE_WIDTH)})
+logger_console = Console()
 
 _logger_handler = RichHandler(
     show_path=False,

--- a/pipen/version.py
+++ b/pipen/version.py
@@ -1,3 +1,3 @@
 """Provide version of pipen"""
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"

--- a/poetry.lock
+++ b/poetry.lock
@@ -396,7 +396,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "pyparam"
-version = "0.5.2"
+version = "0.5.3"
 description = "Powerful parameter processing."
 category = "main"
 optional = false
@@ -993,8 +993,8 @@ pygments = [
     {file = "Pygments-2.12.0.tar.gz", hash = "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb"},
 ]
 pyparam = [
-    {file = "pyparam-0.5.2-py3-none-any.whl", hash = "sha256:1d22408e8db3adfa9a5f356a9d0f4a924bafcccc3df2f2526c1c25263dc89c46"},
-    {file = "pyparam-0.5.2.tar.gz", hash = "sha256:b33dc69b67450600eea780b11a9092ba12054d922367617f3c7eb47eea9723a2"},
+    {file = "pyparam-0.5.3-py3-none-any.whl", hash = "sha256:dfc289b56c7be9f16c6f3697ec6863ef1e577dae90bc388be878d3ba082c349d"},
+    {file = "pyparam-0.5.3.tar.gz", hash = "sha256:574b5bce18ff1513e47043d6a21a3a192cf1435eda232999411c743fffb97387"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "pipen"
-version = "0.3.3"
+version = "0.3.4"
 description = "A pipeline framework for python"
 authors = [ "pwwang <pwwang@pwwang.com>",]
 license = "MIT"

--- a/tests/test_pipen.py
+++ b/tests/test_pipen.py
@@ -79,11 +79,11 @@ def test_no_next_procs(pipen):
 def test_plugins_are_pipeline_dependent(pipen, pipen_with_plugin, caplog):
     simproc = Proc.from_proc(SimpleProc)
     pipen_with_plugin.set_starts(simproc).run()
-    assert "SimplePlugin" in caplog.text
+    assert "simpleplugin" in caplog.text
 
     caplog.clear()
     pipen.set_starts(simproc).run()  # No simple plugin enabled
-    assert "SimplePlugin" not in caplog.text
+    assert "simpleplugin" not in caplog.text
 
 
 def test_set_starts_error(pipen):


### PR DESCRIPTION
- ✨ Print pipen version in CLI: pipen plugins
- 🩹 Make use of full terminal width for non-panel elements in log
- 🩹 Extend width to 256 when terminal width cannot be detected while logging (most likely logging to a text file)