### PR TITLE
0.5.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Change Log
 
+## 0.5.0
+
+- ➖ Remove more-itertools
+- ✨ Add `ProcGroup` to manage groups of processes.
+
+    ```python
+    from pipen import Proc, ProcGroup
+
+    class MyGroup(ProcGroup):
+
+        @ProcGroup.add_proc
+        def my_proc(self):
+            class MyProc(Proc):
+                ...
+            return MyProc
+
+        @ProcGroup.add_proc
+        def my_proc2(self):
+            class MyProc2(Proc):
+                requires = self.my_proc
+                ...
+            return MyProc2
+
+    pg = MyGroup()
+    # Run as a pipeline
+    pg.as_pipen().set_data(...).run()
+
+    # Integrate into a pipeline
+    <proc_of_a_pipeline>.requires = pg.my_proc2
+    ```
+
 ## 0.4.6
 
 - 🐛 Fix plugins command not listing plugins

--- a/docs/proc-group.md
+++ b/docs/proc-group.md
@@ -1,0 +1,114 @@
+A process group is a collection of processes that are related to each other. It is a convenient way to manage a set of processes.
+
+With `pipen`, not only a process can be reused, but also a group of processes can be reused. We just need to define the relationship between the processes in the group, and then we can reuse the group in other pipelines, or even run it directly as a pipeline.
+
+## Define a process group
+
+To define a process group, we need to define a class that inherits from `pipen.procgroup.ProcGroup`. The class name will be the name of the group, unless we specify a `name` attribute. The class should have a `build` method that defines the relationship between the processes in the group. It should return a list of processes, that are the start processes of the group.
+
+```python
+from pipen.procgroup import ProcGroup
+
+class MyGroup(ProcGroup):
+    def build(self):
+        ...
+```
+
+Note that the subclasses of `ProcGroup` are singleton classes. If you need to define multiple groups, you can define a base class and then inherit from it.
+
+## Add processes to a group
+
+There are two ways to add processes to a group.
+
+1. Use the `pg.add_proc()` decorator, where `pg` is the process group instance.
+
+    ```python
+    from pipen import Proc, ProcGroup
+
+    class MyGroup(ProcGroup):
+        def build(self):
+            return [self.MyProc]
+
+    pg = MyGroup()
+
+    @pg.add_proc
+    class MyProc(Proc):
+        ...
+    ```
+
+2. Use the `ProcGroup.define_proc()` decorator to decorate a property of the group class.
+
+    ```python
+    from pipen import Proc, ProcGroup
+
+    class MyGroup(ProcGroup):
+
+        def build(self):
+            return [self.my_proc]
+
+        @ProcGroup.define_proc
+        def my_proc(self):
+            class MyProc(Proc):
+                ...
+            return MyProc
+    ```
+
+The second method make sure that the subclasses of `MyGroup` have different instances of `MyProc`. This is useful when we want to define a group that can be reused in different pipelines.
+
+## Run a process group as a pipeline
+
+To run a process group as a pipeline, we can convert it to a pipeline using the `as_pipen()` method. The method takes the same arguments as the `Pipen` constructor.
+
+```python
+from pipen import Proc, ProcGroup
+
+class MyGroup(ProcGroup):
+    def build(self):
+        return [self.MyProc]
+
+pg = MyGroup()
+
+@pg.add_proc
+class MyProc(Proc):
+    ...
+
+# build is called automatically
+pg.as_pipen().set_data(...).run()
+```
+
+## Integrate a process group into a pipeline
+
+```python
+from pipen import Proc, ProcGroup
+
+class MyGroup(ProcGroup):
+    def build(self):
+        self.my_proc2.requires = self.my_proc
+        return self.my_proc
+
+    @ProcGroup.define_proc
+    def my_proc(self):
+        class MyProc(Proc):
+            ...
+        return MyProc
+
+    @ProcGroup.define_proc
+    def my_proc2(self):
+        class MyProc2(Proc):
+            ...
+        return MyProc2
+
+pg = MyGroup()
+
+class PrepareData(Proc):
+    ...
+
+class PostGroup(Proc):
+    requires = pg.my_proc2
+
+# has to call build() manually to build the relationship
+pg.build().requires = PrepareData
+# PostGroup.requires = pg.my_proc2
+
+pipen = Pipen().set_starts(PrepareData).set_data(...).run()
+```

--- a/docs/proc-group.md
+++ b/docs/proc-group.md
@@ -4,30 +4,28 @@ With `pipen`, not only a process can be reused, but also a group of processes ca
 
 ## Define a process group
 
-To define a process group, we need to define a class that inherits from `pipen.procgroup.ProcGroup`. The class name will be the name of the group, unless we specify a `name` attribute. The class should have a `build` method that defines the relationship between the processes in the group. It should return a list of processes, that are the start processes of the group.
+To define a process group, we need to define a class that inherits from `pipen.procgroup.ProcGroup`. The class name will be the name of the group, unless we specify a `name` attribute.
 
 ```python
 from pipen.procgroup import ProcGroup
 
 class MyGroup(ProcGroup):
-    def build(self):
-        ...
+    ...
 ```
 
 Note that the subclasses of `ProcGroup` are singleton classes. If you need to define multiple groups, you can define a base class and then inherit from it.
 
 ## Add processes to a group
 
-There are two ways to add processes to a group.
+There are two ways to add processes to a group, using `pg.add_proc` or `ProcGroup.add_proc`, where `pg` is a process group instance. The first method is used after the group is instantiated and it decorates a process class directly. The second method is used before the group is instantiated and it decorates a property of `ProcGroup` that returns a process.
 
-1. Use the `pg.add_proc()` decorator, where `pg` is the process group instance.
+1. Using the `pg.add_proc()` decorator.
 
     ```python
     from pipen import Proc, ProcGroup
 
     class MyGroup(ProcGroup):
-        def build(self):
-            return [self.MyProc]
+        ...
 
     pg = MyGroup()
 
@@ -36,24 +34,45 @@ There are two ways to add processes to a group.
         ...
     ```
 
-2. Use the `ProcGroup.define_proc()` decorator to decorate a property of the group class.
+2. Using the `ProcGroup.add_proc()` decorator to decorate a property of the group class.
 
     ```python
     from pipen import Proc, ProcGroup
 
     class MyGroup(ProcGroup):
 
-        def build(self):
-            return [self.my_proc]
-
-        @ProcGroup.define_proc
+        @ProcGroup.add_proc
         def my_proc(self):
             class MyProc(Proc):
                 ...
             return MyProc
     ```
 
-The second method make sure that the subclasses of `MyGroup` have different instances of `MyProc`. This is useful when we want to define a group that can be reused in different pipelines.
+This method adds a process at runtime, so it is useful when we want to add processes to a group dynamically.
+
+## Access processes in a group
+
+We can access the processes in a group using the `pg.<proc>` attribute, where `pg` is a process group instance. Note that when we use the `ProcGroup.add_proc` method to add processes, the process name is the name of the property.
+
+However, you can always use `pg.procs.<proc_name>` to access the process, where the `<proc_name>` is the real name of the process.
+
+```python
+from pipen import Proc, ProcGroup
+
+class MyGroup(ProcGroup):
+
+    @ProcGroup.add_proc
+    def my_proc(self):
+        class MyProc(Proc):
+            ...
+        return MyProc
+
+pg = MyGroup()
+assert pg.my_proc.name == 'MyProc'
+assert pg.procs.MyProc.name == 'MyProc'
+```
+
+We can use `pg.starts` to get the start processes of the group, which are the processes that have no required processes. So when you add processes to a group, remember to specify `.requires` for each process, unless they are start processes.
 
 ## Run a process group as a pipeline
 
@@ -63,8 +82,7 @@ To run a process group as a pipeline, we can convert it to a pipeline using the 
 from pipen import Proc, ProcGroup
 
 class MyGroup(ProcGroup):
-    def build(self):
-        return [self.MyProc]
+    ...
 
 pg = MyGroup()
 
@@ -72,7 +90,6 @@ pg = MyGroup()
 class MyProc(Proc):
     ...
 
-# build is called automatically
 pg.as_pipen().set_data(...).run()
 ```
 
@@ -82,20 +99,19 @@ pg.as_pipen().set_data(...).run()
 from pipen import Proc, ProcGroup
 
 class MyGroup(ProcGroup):
-    def build(self):
-        self.my_proc2.requires = self.my_proc
-        return self.my_proc
 
-    @ProcGroup.define_proc
+    @ProcGroup.add_proc
     def my_proc(self):
         class MyProc(Proc):
             ...
         return MyProc
 
-    @ProcGroup.define_proc
+    @ProcGroup.add_proc
     def my_proc2(self):
         class MyProc2(Proc):
+            requires = self.my_proc
             ...
+
         return MyProc2
 
 pg = MyGroup()
@@ -106,9 +122,7 @@ class PrepareData(Proc):
 class PostGroup(Proc):
     requires = pg.my_proc2
 
-# has to call build() manually to build the relationship
-pg.build().requires = PrepareData
-# PostGroup.requires = pg.my_proc2
+pg.my_proc.requires = PrepareData
 
 pipen = Pipen().set_starts(PrepareData).set_data(...).run()
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
     - 'Configurations': 'configurations.md'
     - 'Plugins': 'plugin.md'
     - 'Scheduler': 'scheduler.md'
+    - 'Process group': 'proc-group.md'
     - 'Command line iterface': 'cli.md'
     - 'Examples': 'examples.md'
     - 'Change log': 'CHANGELOG.md'

--- a/pipen/__init__.py
+++ b/pipen/__init__.py
@@ -1,6 +1,7 @@
 """A pipeline framework for python"""
 from .pipen import Pipen
 from .proc import Proc
+from .procgroup import ProcGroup
 
 # Use from pipen.channel import Channel instead of
 # from pipen import Channel

--- a/pipen/proc.py
+++ b/pipen/proc.py
@@ -672,9 +672,14 @@ class Proc(ABC, metaclass=ProcMeta):
 
     def _log_info(self):
         """Log some basic information of the process"""
+        title = (
+            f"{self.__procgroup__.name}/{self.name}"
+            if getattr(self, "__procgroup__", None)
+            else self.name
+        )
         panel = Panel(
             self.desc or "Undescribed",
-            title=self.name,
+            title=title,
             box=box.Box(
                 "╭═┬╮\n"
                 "║ ║║\n"

--- a/pipen/proc.py
+++ b/pipen/proc.py
@@ -268,12 +268,15 @@ class Proc(ABC, metaclass=ProcMeta):
                 kwargs[key] = locs[key]
 
         kwargs["__doc__"] = proc.__doc__
-        return type(name, (proc,), kwargs)
+        out = type(name, (proc,), kwargs)
+        out.__procgroup__ = None
+        return out
 
     def __init_subclass__(cls) -> None:
         """Do the requirements inferring since we need them to build up the
         process relationship
         """
+        # Use __mro__?
         parent = cls.__bases__[-1]
         # cls.requires = cls._compute_requires()
         # triggers cls.__setattr__() to compute requires
@@ -295,6 +298,7 @@ class Proc(ABC, metaclass=ProcMeta):
         cls.scheduler_opts = update_dict(
             parent.scheduler_opts, cls.scheduler_opts
         )
+        cls.__procgroup__ = None
 
     def __init__(self, pipeline: "Pipen" = None) -> None:
         """Constructor

--- a/pipen/procgroup.py
+++ b/pipen/procgroup.py
@@ -1,0 +1,199 @@
+"""Process group that contains a set of processes.
+
+It can be easily used to create a pipeline that runs independently or
+integrated into a larger pipeline.
+
+Runs directly:
+>>> proc_group = ProcGroup(<options>)
+>>> proc_group.as_pipen(<pipeline options>).set_data(<data>).run()
+
+Integrated into a larger pipeline
+>>> proc_group = ProcGroup(<options>)
+>>> # proc could be a process within the larger pipeline
+>>> proc.requires = prog_group.build()
+
+To add a process to the proc group, use the `add_proc` method:
+>>> class MyProcGroup(ProcGroup):
+>>>     def build(self):
+>>>         return [self.MyProc]
+>>>
+>>> proc_group = MyProcGroup(...)
+>>> @proc_group.add_proc
+>>> class MyProc(Proc):
+>>>     ...
+
+Or use the define_proc decorator:
+>>> class MyProcGroup(ProcGroup):
+>>>     def build(self):
+>>>         return [self.MyProc]
+>>>
+>>>     @define_proc
+>>>     def my_proc(self):
+>>>         class MyProc(Proc):
+>>>             # You may use self.options here
+>>>             ...
+>>>         return MyProc
+>>> proc_group = MyProcGroup(...)
+
+You should define the relationship between processes in the `build` method:
+>>> class MyProcGroup(ProcGroup):
+>>>     def build(self):
+>>>         self.MyProc1.requires = [self.MyProc2]
+>>>         return [self.MyProc1]
+
+When run directly, the `build` method will be called automatically. But
+when integrated into a larger pipeline, you should call it manually:
+>>> proc_group = MyProcGroup(...)
+>>> # proc could be a process within the larger pipeline
+>>> proc.requires = proc_group.build()
+"""
+from __future__ import annotations
+from functools import wraps
+
+from os import PathLike
+from types import MethodType
+from typing import Callable, Type, List
+from abc import ABC, ABCMeta
+from diot import Diot
+
+from .utils import cached_property
+from .pipen import Pipen
+from .proc import Proc
+
+
+class ProcGropuMeta(ABCMeta):
+    """Meta class for ProcGroup"""
+
+    _INST = None
+
+    def __call__(cls, *args, **kwds):
+        """Make sure Proc subclasses are singletons
+
+        Args:
+            *args: and
+            **kwds: Arguments for the constructor
+
+        Returns:
+            The Proc instance
+        """
+        if cls._INST is None:
+            cls._INST = super().__call__(*args, **kwds)
+
+        return cls._INST
+
+
+class ProcGroup(ABC, metaclass=ProcGropuMeta):
+    """A group of processes that can be run independently or
+    integrated into a larger pipeline.
+    """
+
+    name: str | None = None
+    DEFAULTS = Diot()
+    PRESERVED = {
+        "opts",
+        "name",
+        "build",
+        "add_proc",
+        "as_pipen",
+        "procs",
+    }
+
+    def __init__(self, **opts) -> None:
+        self.opts = Diot(self.__class__.DEFAULTS or {}) | (opts or {})
+        self.name = self.__class__.name or self.__class__.__name__
+
+    def build(self) -> List[Type[Proc]] | Type[Proc]:
+        """Build the pipeline"""
+
+    @property
+    def procs(self) -> Diot:
+        """Get all processes"""
+        return Diot(
+            {
+                k: v
+                for k, v in
+                self.__dict__.items()
+                if isinstance(v, Proc) or (
+                    isinstance(v, type) and issubclass(v, Proc)
+                )
+            }
+        )
+
+    def add_proc(
+        self,
+        proc: Type[Proc] | None = None,
+    ) -> Type[Proc] | Callable[[Type[Proc]], Type[Proc]]:
+        """Add a process to the proc group
+
+        Args:
+            proc: The process to add
+            start: Whether the process is a start process
+            end: Whether the process is an end process
+
+        Returns:
+            The process added
+        """
+        if proc is None:
+            return self.add_proc  # type: ignore
+
+        if proc.name in self.__class__.PRESERVED:
+            raise ValueError(
+                f"Process name `{proc.name}` is reserved for ProcGroup"
+            )
+        setattr(self, proc.name, proc)
+        proc.__procgroup__ = self
+        return proc
+
+    def as_pipen(
+        self,
+        name: str = None,
+        desc: str = None,
+        outdir: PathLike = None,
+        **kwargs,
+    ) -> Pipen:
+        """Convert the pipeline to a Pipen instance
+
+        Args:
+            name: The name of the pipeline
+            desc: The description of the pipeline
+            outdir: The output directory of the pipeline
+            **kwargs: The keyword arguments to pass to Pipen
+
+        Returns:
+            The Pipen instance
+        """
+        name = name or self.__class__.__name__
+        if self.__doc__:
+            desc = desc or self.__doc__.lstrip().splitlines()[0]
+
+        pipe = Pipen(name=name, desc=desc, outdir=outdir, **kwargs)
+        pipe.set_start(self.build())
+        return pipe
+
+    def define_proc(
+        method: MethodType | None = None,
+    ) -> property | Callable[[MethodType], property]:
+        """Define a process by a method of ProcGroup and add it to the
+        proc group
+
+        This is used to decorate a method of ProcGroup that returns a process.
+        Different from procgroup.add_proc(), this allows you to create the
+        process at runtime.
+
+        Args:
+            method: The method to define the process. It will finally work as a
+                property, so it should not have any arguments.
+
+        Returns:
+            The process defined
+        """
+        if method is None:
+            return ProcGroup.define_proc  # type: ignore
+
+        @wraps(method)
+        def wrapper(self):
+            proc = method(self)
+            proc.__procgroup__ = self
+            return proc
+
+        return cached_property(wrapper)

--- a/pipen/procgroup.py
+++ b/pipen/procgroup.py
@@ -92,6 +92,10 @@ class ProcGroup(ABC, metaclass=ProcGropuMeta):
         self.starts = []
         self.procs = Diot()
 
+        self._load_runtime_procs()
+
+    def _load_runtime_procs(self):
+        """Load all processes that are added at runtime"""
         # Load all processes if they are decorated by ProcGroup.add_proc
         for name, attr in self.__class__.__dict__.items():
             if isinstance(attr, cached_property):

--- a/pipen/procgroup.py
+++ b/pipen/procgroup.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 
 from os import PathLike
 from functools import wraps
-from typing import Callable, Type
+from typing import Callable, Type, List
 from abc import ABC, ABCMeta
 from diot import Diot
 
@@ -89,7 +89,7 @@ class ProcGroup(ABC, metaclass=ProcGropuMeta):
     def __init__(self, **opts) -> None:
         self.opts = Diot(self.__class__.DEFAULTS or {}) | (opts or {})
         self.name = self.__class__.name or self.__class__.__name__
-        self.starts = []
+        self.starts: List[Type[Proc]] = []
         self.procs = Diot()
 
         self._load_runtime_procs()
@@ -104,7 +104,7 @@ class ProcGroup(ABC, metaclass=ProcGropuMeta):
     def add_proc(
         self_or_method: ProcGroup | Callable[[ProcGroup], Type[Proc]],
         proc: Type[Proc] | None = None,
-    ) -> Type[Proc] | Callable[[Type[Proc]], Type[Proc]]:
+    ) -> Type[Proc] | cached_property:
         """Add a process to the proc group
 
         It works either as a decorator to the process directly or as a

--- a/pipen/utils.py
+++ b/pipen/utils.py
@@ -1,6 +1,8 @@
 """Provide some utilities"""
 import logging
 import textwrap
+from itertools import groupby
+from operator import itemgetter
 from io import StringIO
 from os import PathLike, get_terminal_size
 from collections import defaultdict
@@ -338,8 +340,8 @@ def brief_list(blist: List[int]) -> str:
         The string to show for the briefed list.
     """
     ret = []
-    for group in consecutive_groups(blist):
-        list_group = list(group)
+    for _, g in groupby(enumerate(blist), lambda x: x[0] - x[1]):
+        list_group = list(map(itemgetter(1), g))
         if len(list_group) > 1:
             ret.append(f"{list_group[0]}-{list_group[-1]}")
         else:

--- a/pipen/version.py
+++ b/pipen/version.py
@@ -1,3 +1,3 @@
 """Provide version of pipen"""
 
-__version__ = "0.4.6"
+__version__ = "0.5.0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -86,14 +86,14 @@ trio = ["trio (>=0.16,<0.22)"]
 
 [[package]]
 name = "argx"
-version = "0.2.3"
+version = "0.2.4"
 description = "Super-charged argparse for python"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "argx-0.2.3-py3-none-any.whl", hash = "sha256:516199922dc4ebb78a1821d7db3b3bd981361f3daf27735a35f550b7b22cca98"},
-    {file = "argx-0.2.3.tar.gz", hash = "sha256:452983b1e9f22fd00fa02cf2a34532b3cc37e324f4f5c6e03beff2d8189c9084"},
+    {file = "argx-0.2.4-py3-none-any.whl", hash = "sha256:91b7fa8aad3b770c4fe159bf37d84ba85535b73f16a25067855477fbf9d3ef1d"},
+    {file = "argx-0.2.4.tar.gz", hash = "sha256:8e56650b67ff6f00c4564906e628a6efb865534351f85512b6dd5b0f9ebff8fb"},
 ]
 
 [package.dependencies]
@@ -612,18 +612,6 @@ python-versions = ">=3.7"
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
-]
-
-[[package]]
-name = "more-itertools"
-version = "8.14.0"
-description = "More routines for operating on iterables, beyond itertools"
-category = "main"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "more-itertools-8.14.0.tar.gz", hash = "sha256:c09443cd3d5438b8dafccd867a6bc1cb0894389e90cb53d227456b0b0bccb750"},
-    {file = "more_itertools-8.14.0-py3-none-any.whl", hash = "sha256:1bc4f91ee5b1b31ac7ceacc17c09befe6a40a503907baf9c839c229b5095cfd2"},
 ]
 
 [[package]]
@@ -1293,4 +1281,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7.1" # align with datar/pandas
-content-hash = "b1c4f0265d552da3235469b87d2064a3357df32dbed194ad5321b0b422fd4e25"
+content-hash = "593b9f1c723f44f0538dcc4e492e69b345b00a618c3196dd6b7a7adcecd16cc4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ pandas = "^1.3"
 python-slugify = "^8"
 enlighten = "^1"
 cached-property = "^1"
-more-itertools = "^8"
 argx = "^0.2"
 xqute = "^0.1"
 ## included in xqute

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "pipen"
-version = "0.4.6"
+version = "0.5.0"
 description = "A pipeline framework for python"
 authors = [ "pwwang <pwwang@pwwang.com>",]
 license = "MIT"

--- a/tests/test_procgroup.py
+++ b/tests/test_procgroup.py
@@ -1,0 +1,142 @@
+import pytest  # noqa: F401
+
+from pipen import Proc, Pipen
+from pipen.procgroup import ProcGroup
+
+
+def test_singleton():
+    class PG(ProcGroup):
+        def build(self):
+            pass
+
+    assert PG() is PG()
+
+
+def test_option_overrides_defaults():
+    class PG(ProcGroup):
+        DEFAULTS = {"a": 1}
+
+        def build(self):
+            pass
+
+    pg = PG(a=2)
+    assert pg.opts.a == 2
+
+
+def test_add_proc():
+
+    class PG(ProcGroup):
+        def build(self):
+            pass
+
+    pg = PG()
+
+    @pg.add_proc
+    class P1(Proc):
+        pass
+
+    assert pg.P1 is P1
+    assert len(pg.procs) == 1
+    assert pg.procs.P1 is P1
+
+
+def test_define_proc():
+
+    class P1(Proc): pass  # noqa: E701
+    class P2(Proc): pass  # noqa: E701
+    class P3(Proc): pass  # noqa: E701
+
+    class PG(ProcGroup):
+        def build(self):
+            self.p2.requires = [self.p1]
+            self.p3.depends = [self.p2]
+            return [self.p1]
+
+        @ProcGroup.define_proc
+        def p1(self):
+            return P1
+
+        @ProcGroup.define_proc()
+        def p2(self):
+            return P2
+
+        @ProcGroup.define_proc()
+        def p3(self):
+            return P3
+
+    pg = PG()
+    assert pg.build() == [P1]
+
+    assert pg.p1 is P1
+    assert pg.p2 is P2
+    assert pg.p3 is P3
+
+
+def test_as_pipen():
+    class PG(ProcGroup):
+        """A pipeline group"""
+        def build(self):
+            pass
+
+    pg = PG()
+
+    @pg.add_proc
+    class P1(Proc):
+        ...
+
+    p = pg.as_pipen()
+    assert isinstance(p, Pipen)
+    assert p.desc == "A pipeline group"
+
+    p = pg.as_pipen(desc="Test desc")
+    assert p.desc == "Test desc"
+
+
+def test_procgroup_cleared_when_subclassed():
+    class PG(ProcGroup):
+        def build(self):
+            pass
+
+    pg = PG()
+
+    @pg.add_proc()
+    class P1(Proc):
+        ...
+
+    assert P1.__procgroup__ is pg
+
+    class P2(P1):
+        ...
+
+    assert P2.__procgroup__ is None
+
+
+def test_name():
+    class PG(ProcGroup):
+        def build(self):
+            pass
+
+    pg = PG()
+    assert pg.name == "PG"
+
+    class PG2(ProcGroup):
+        name = "PG10"
+
+        def build(self):
+            pass
+
+    pg2 = PG2()
+    assert pg2.name == "PG10"
+
+
+def test_invliad_proc_name():
+    class PG(ProcGroup):
+        def build(self):
+            pass
+
+    pg = PG()
+
+    with pytest.raises(ValueError, match="Process name `opts` is reserved"):
+        @pg.add_proc()
+        class opts(Proc):
+            ...


### PR DESCRIPTION
- ➖ Remove more-itertools
- ✨ Add `ProcGroup` to manage groups of processes.

    ```python
    from pipen import Proc, ProcGroup

    class MyGroup(ProcGroup):

        @ProcGroup.add_proc
        def my_proc(self):
            class MyProc(Proc):
                ...
            return MyProc

        @ProcGroup.add_proc
        def my_proc2(self):
            class MyProc2(Proc):
                requires = self.my_proc
                ...
            return MyProc2

    pg = MyGroup()
    # Run as a pipeline
    pg.as_pipen().set_data(...).run()

    # Integrate into a pipeline
    <proc_of_a_pipeline>.requires = pg.my_proc2
    ```