### PR TITLE
0.6.1

### DIFF
--- a/pipen/defaults.py
+++ b/pipen/defaults.py
@@ -12,7 +12,7 @@ xqute_logger.removeHandler(xqute_logger.handlers[0])
 
 LOGGER_NAME = "main"
 CONFIG_FILES = (
-    Path("~/.pipen.toml"),
+    Path("~/.pipen.toml").expanduser(),
     "./.pipen.toml",
     "PIPEN.osenv",
 )

--- a/pipen/version.py
+++ b/pipen/version.py
@@ -1,3 +1,3 @@
 """Provide version of pipen"""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "pipen"
-version = "0.6.0"
+version = "0.6.1"
 description = "A pipeline framework for python"
 authors = [ "pwwang <pwwang@pwwang.com>",]
 license = "MIT"


### PR DESCRIPTION
🐛 Fix path expansion for `~/.pipen.toml` in defaults.