### PR TITLE
0.9.3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.9.3
+
+- 🐛 Set logging.lastResort to null handler
+- ✨ Allow to assign process directly to proc groups
+- 🔧 Change progress bar description length to 24
+
 ## 0.9.2
 
 - 🎨 Rename to main plugin to core

--- a/pipen/procgroup.py
+++ b/pipen/procgroup.py
@@ -99,6 +99,8 @@ class ProcGroup(ABC, metaclass=ProcGropuMeta):
         for name, attr in self.__class__.__dict__.items():
             if isinstance(attr, cached_property):
                 getattr(self, name)
+            elif isinstance(attr, type) and issubclass(attr, Proc):
+                self.add_proc(attr)
 
     def add_proc(
         self_or_method: ProcGroup | Callable[[ProcGroup], Type[Proc]],
@@ -142,14 +144,8 @@ class ProcGroup(ABC, metaclass=ProcGropuMeta):
             if proc is None:
                 return None
 
-            if (
-                not isinstance(proc, Proc)
-                and (not isinstance(proc, type) or not issubclass(proc, Proc))
-            ):
-                raise ValueError(
-                    f"`{proc}` is not a process "
-                    "(either a subclass or an instance of Proc)"
-                )
+            if (not isinstance(proc, type) or not issubclass(proc, Proc)):
+                raise ValueError(f"`{proc}` is not a Proc subclass")
 
             proc.__meta__["procgroup"] = self
             if not proc.requires:

--- a/pipen/progressbar.py
+++ b/pipen/progressbar.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # [12/02/20 12:44:06] I core
 #                 pipeline: 100%|
 # |        desc_len      |
-PBAR_DESC_LEN = 23
+PBAR_DESC_LEN = 24
 
 
 class ProcPBar:

--- a/pipen/utils.py
+++ b/pipen/utils.py
@@ -91,8 +91,8 @@ class RichConsole(Console):
         return out.rstrip() + "\n"
 
 
+logging.lastResort = logging.NullHandler()  # type: ignore
 logger_console = RichConsole()
-
 _logger_handler = RichHandler(
     show_path=False,
     show_level=True,

--- a/pipen/version.py
+++ b/pipen/version.py
@@ -1,3 +1,3 @@
 """Provide version of pipen"""
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"

--- a/poetry.lock
+++ b/poetry.lock
@@ -745,14 +745,14 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pytest"
-version = "7.3.0"
+version = "7.3.1"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.3.0-py3-none-any.whl", hash = "sha256:933051fa1bfbd38a21e73c3960cebdad4cf59483ddba7696c48509727e17f201"},
-    {file = "pytest-7.3.0.tar.gz", hash = "sha256:58ecc27ebf0ea643ebfdf7fb1249335da761a00c9f955bcd922349bcb68ee57d"},
+    {file = "pytest-7.3.1-py3-none-any.whl", hash = "sha256:3799fa815351fea3a5e96ac7e503a96fa51cc9942c3753cda7651b93c1cfa362"},
+    {file = "pytest-7.3.1.tar.gz", hash = "sha256:434afafd78b1d78ed0addf160ad2b77a30d35d4bdf8af234fe621919d9ed15e3"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "pipen"
-version = "0.9.2"
+version = "0.9.3"
 description = "A pipeline framework for python"
 authors = [ "pwwang <pwwang@pwwang.com>",]
 license = "MIT"

--- a/tests/test_procgroup.py
+++ b/tests/test_procgroup.py
@@ -142,3 +142,17 @@ def test_invliad_proc_name():
         @pg.add_proc
         class opts(Proc):
             ...
+
+
+def test_add_proc_directly():
+    class P1(Proc):
+        ...
+
+    class PG(ProcGroup):
+        p1 = P1
+
+    pg = PG()
+
+    assert pg.p1 is P1
+    assert pg.procs == {"P1": P1}
+    assert pg.starts == [P1]


### PR DESCRIPTION
- 🐛 Set logging.lastResort to null handler
- ✨ Allow to assign process directly to proc groups
- 🔧 Change progress bar description length to 24