### PR TITLE
🔖 0.10.6

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.10.6
+
+- 🐛 Fix "DeprecationWarning: np.find_common_type is deprecated" from pandas (due to numpy 1.25 update)
+
 ## 0.10.5
 
 - 🎨 Allow starts to be set as a tuple

--- a/pipen/proc.py
+++ b/pipen/proc.py
@@ -589,9 +589,11 @@ class Proc(ABC, metaclass=ProcMeta):
 
         # try match the column names
         # if none matched, use the first columns
-        rest_cols = out.data.columns.difference(out.type, False)
+        # rest_cols = out.data.columns.difference(out.type, False)
+        rest_cols = [col for col in out.data.columns if col not in out.type]
         len_rest_cols = len(rest_cols)
-        matched_cols = out.data.columns.intersection(out.type)
+        # matched_cols = out.data.columns.intersection(out.type)
+        matched_cols = [col for col in out.data.columns if col in out.type]
         needed_cols = [col for col in out.type if col not in matched_cols]
         len_needed_cols = len(needed_cols)
 

--- a/pipen/version.py
+++ b/pipen/version.py
@@ -1,3 +1,3 @@
 """Provide version of pipen"""
 
-__version__ = "0.10.5"
+__version__ = "0.10.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "pipen"
-version = "0.10.5"
+version = "0.10.6"
 description = "A pipeline framework for python"
 authors = [ "pwwang <pwwang@pwwang.com>",]
 license = "MIT"


### PR DESCRIPTION
- 🐛 Fix "DeprecationWarning: np.find_common_type is deprecated" from pandas (due to numpy 1.25 update)