### PR TITLE
🔖 0.12.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.12.2
+
+- Append `sys.argv[1:]` by default when `cli_args` is `None` in `utils.load_pipeline()`
+
 ## 0.12.1
 
 - Add utils.is_loading_pipeline() to check if pipeline is loading

--- a/pipen/utils.py
+++ b/pipen/utils.py
@@ -629,7 +629,7 @@ def _get_obj_from_spec(spec: str) -> Any:
 
 async def load_pipeline(
     obj: str | Type[Proc] | Type[ProcGroup] | Type[Pipen],
-    cli_args: Sequence[str] = (),
+    cli_args: Sequence[str] = None,
     **kwargs: Any,
 ) -> Pipen:
     """Load a pipeline from a Pipen, Proc or ProcGroup object
@@ -691,6 +691,8 @@ async def load_pipeline(
         )
 
     old_argv = sys.argv
+    if cli_args is None:
+        cli_args = sys.argv[1:]
     sys.argv = [LOADING_ARGV0] + list(cli_args)
     try:
         # Initialize the pipeline so that the arguments definied by

--- a/pipen/version.py
+++ b/pipen/version.py
@@ -1,3 +1,3 @@
 """Provide version of pipen"""
 
-__version__ = "0.12.1"
+__version__ = "0.12.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "pipen"
-version = "0.12.1"
+version = "0.12.2"
 description = "A pipeline framework for python"
 authors = [ "pwwang <pwwang@pwwang.com>",]
 license = "MIT"


### PR DESCRIPTION
- Append `sys.argv[1:]` by default when `cli_args` is `None` in `utils.load_pipeline()`